### PR TITLE
Add CSV destination (requires Ruby 2.3+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
-  - 2.4.0
-  - 2.3.4
-  - jruby-1.7
-  - jruby-9
+  - 2.4.3
+  - 2.3.6
+  - jruby-9.1.15.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,5 @@ before_install:
 rvm:
   - 2.4.0
   - 2.3.4
-  - 2.2
-  - 2.1
-  - 2.0
   - jruby-1.7
   - jruby-9

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 HEAD
 ----
 
+- Breaking: Kiba::Common requires Ruby 2.3+ from now on.
 - New: Kiba::Common::Destinations:CSV allows to write ruby hashes to a CSV file.
 
 0.0.2

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 HEAD
 ----
 
+- New: Kiba::Common::Destinations:CSV allows to write ruby hashes to a CSV file.
+
 0.0.2
 ----
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A way to dump `Hash` rows as CSV, using the first row's keys as headers.
 
 All rows are expected to have the exact same set of keys as the first row.
 
-Use the `csv_options` keyword to control the output format like you would do when using [Ruby CSV class] (http://ruby-doc.org/stdlib-2.4.0/libdoc/csv/rdoc/CSV.html#method-c-new).
+Use the `csv_options` keyword to control the output format like you would do when using [Ruby CSV class](http://ruby-doc.org/stdlib-2.4.0/libdoc/csv/rdoc/CSV.html#method-c-new).
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Then see below for each module usage & require clause.
 
 ### Kiba::Common::Destinations::CSV
 
-A way to dump `Hash` rows as CSV, using the first row's keys as headers.
+A way to dump `Hash` rows as CSV.
 
 All rows are expected to have the exact same set of keys as the first row.
+
+The headers will be the first row keys, unless you pass an array of keys via `headers`.
+
+All keys are mandatory (although they can have a nil value).
 
 Use the `csv_options` keyword to control the output format like you would do when using [Ruby CSV class](http://ruby-doc.org/stdlib-2.4.0/libdoc/csv/rdoc/CSV.html#method-c-new).
 
@@ -31,25 +35,19 @@ Usage:
 ```ruby
 require 'kiba-common/destinations/csv'
 
-destination Kiba::Common::Destinations::CSV,
-  filename: 'output.csv',
-  csv_options: { headers: true } # this is the default
-  
-# if you need a different separator, use:
-destination Kiba::Common::Destinations::CSV,
-  filename: 'output.csv',
-  csv_options: { col_sep: ';', headers: true }
-```
-
-If you do not want to output some fields, you are expected to drop them from the rows before:
-
-```ruby
-require 'active_support/core_ext/hash/except'
-
-transform { |r| r.except(:some_field) }
-
+# by default, the headers will be picked from the first row:
 destination Kiba::Common::Destinations::CSV,
   filename: 'output.csv'
+
+# if you need a different separator:
+destination Kiba::Common::Destinations::CSV,
+  filename: 'output.csv',
+  csv_options: { col_sep: ';' }
+  
+# to enforce a specific set of headers:
+destination Kiba::Common::Destinations::CSV,
+  filename: 'output.csv',
+  headers: [:field, :other_field]
 ```
 
 ### Kiba::Common::DSLExtensions::Logger

--- a/README.md
+++ b/README.md
@@ -12,7 +12,41 @@ gem 'kiba-common'
 
 Then see below for each module usage & require clause.
 
-## Available extensions
+## Available components
+
+### Kiba::Common::Destinations::CSV
+
+A way to dump `Hash` rows as CSV, using the first row's keys as headers.
+
+All rows are expected to have the exact same set of keys as the first row.
+
+Use the `csv_options` keyword to control the output format like you would do when using [Ruby CSV class] (http://ruby-doc.org/stdlib-2.4.0/libdoc/csv/rdoc/CSV.html#method-c-new).
+
+Usage:
+
+```ruby
+require 'kiba-common/destinations/csv'
+
+destination Kiba::Common::Destinations::CSV,
+  filename: 'output.csv',
+  csv_options: { headers: true } # this is the default
+  
+# if you need a different separator, use:
+destination Kiba::Common::Destinations::CSV,
+  filename: 'output.csv',
+  csv_options: { col_sep: ';', headers: true }
+```
+
+If you do not want to output some fields, you are expected to drop them from the rows before:
+
+```ruby
+require 'active_support/core_ext/hash/except'
+
+transform { |r| r.except(:some_field) }
+
+destination Kiba::Common::Destinations::CSV,
+  filename: 'output.csv'
+```
 
 ### Kiba::Common::DSLExtensions::Logger
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ gem 'kiba-common'
 
 Then see below for each module usage & require clause.
 
+## Supported Ruby versions
+
+`kiba-common` currently supports Ruby 2.3+ and JRuby (with its default 1.9 syntax). See [test matrix](https://travis-ci.org/thbar/kiba-common).
+
 ## Available components
 
 ### Kiba::Common::Destinations::CSV

--- a/lib/kiba-common/destinations/csv.rb
+++ b/lib/kiba-common/destinations/csv.rb
@@ -4,24 +4,23 @@ module Kiba
   module Common
     module Destinations
       class CSV
-        attr_reader :filename, :csv_options
+        attr_reader :filename, :csv_options, :csv, :headers
         
-        def initialize(filename:, csv_options: nil)
+        def initialize(filename:, csv_options: nil, headers: nil)
           @filename = filename
           @csv_options = csv_options
+          @headers = headers
         end
         
         def write(row)
           @csv ||= ::CSV.open(filename, 'wb', csv_options)
-          @headers ||= begin
-            @csv << (headers = row.keys)
-            headers
-          end
-          @csv << row.fetch_values(*headers)
+          @headers ||= row.keys
+          @headers_written ||= (csv << headers ; true)
+          csv << row.fetch_values(*@headers)
         end
         
         def close
-          @csv&.close
+          csv&.close
         end
       end
     end

--- a/lib/kiba-common/destinations/csv.rb
+++ b/lib/kiba-common/destinations/csv.rb
@@ -1,0 +1,32 @@
+require 'csv'
+
+module Kiba
+  module Common
+    module Destinations
+      class CSV
+        attr_reader :filename, :csv_options
+        
+        def initialize(filename:, csv_options: {headers: true})
+          @filename = filename
+          @csv_options = csv_options
+          unless @csv_options[:headers] == true
+            fail ":headers CSV option must be set to true for now"
+          end
+        end
+        
+        def write(row)
+          @csv ||= ::CSV.open(filename, 'wb', csv_options)
+          @headers ||= begin
+            @csv << (headers = row.keys)
+            headers
+          end
+          @csv << row.fetch_values(*headers)
+        end
+        
+        def close
+          @csv&.close
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba-common/destinations/csv.rb
+++ b/lib/kiba-common/destinations/csv.rb
@@ -6,12 +6,9 @@ module Kiba
       class CSV
         attr_reader :filename, :csv_options
         
-        def initialize(filename:, csv_options: {headers: true})
+        def initialize(filename:, csv_options: nil)
           @filename = filename
           @csv_options = csv_options
-          unless @csv_options[:headers] == true
-            fail ":headers CSV option must be set to true for now"
-          end
         end
         
         def write(row)

--- a/test/test_csv_destination.rb
+++ b/test/test_csv_destination.rb
@@ -1,0 +1,29 @@
+require_relative 'helper'
+require 'kiba'
+require 'kiba-common/destinations/csv'
+
+class TestCSVDestination < Minitest::Test
+  TEST_FILENAME = 'output.csv'
+    
+  def teardown
+    File.delete(TEST_FILENAME)
+  end
+
+  def test_write_with_options
+    job = Kiba.parse do
+      source TestEnumerableSource, [
+        {name: "world", age: 999}
+      ]
+      destination Kiba::Common::Destinations::CSV,
+        filename: TEST_FILENAME,
+        csv_options: { col_sep: ';', headers: true }
+    end
+
+    Kiba.run(job)
+    
+    assert_equal IO.read(TEST_FILENAME), <<~CSV
+      name;age
+      world;999
+    CSV
+  end
+end

--- a/test/test_csv_destination.rb
+++ b/test/test_csv_destination.rb
@@ -16,7 +16,7 @@ class TestCSVDestination < Minitest::Test
       ]
       destination Kiba::Common::Destinations::CSV,
         filename: TEST_FILENAME,
-        csv_options: { col_sep: ';', headers: true }
+        csv_options: { col_sep: ';' }
     end
 
     Kiba.run(job)

--- a/test/test_csv_destination.rb
+++ b/test/test_csv_destination.rb
@@ -6,24 +6,43 @@ class TestCSVDestination < Minitest::Test
   TEST_FILENAME = 'output.csv'
     
   def teardown
-    File.delete(TEST_FILENAME)
+    File.delete(TEST_FILENAME) if File.exist?(TEST_FILENAME)
   end
 
-  def test_write_with_options
+  def run_etl(csv_options: nil, headers: nil)
     job = Kiba.parse do
       source TestEnumerableSource, [
         {name: "world", age: 999}
       ]
       destination Kiba::Common::Destinations::CSV,
         filename: TEST_FILENAME,
-        csv_options: { col_sep: ';' }
+        csv_options: csv_options,
+        headers: headers
     end
 
     Kiba.run(job)
     
-    assert_equal IO.read(TEST_FILENAME), <<~CSV
+    IO.read(TEST_FILENAME)
+  end
+  
+  def test_classic
+    assert_equal <<~CSV, run_etl
+      name,age
+      world,999
+    CSV
+  end
+  
+  def test_csv_options
+    assert_equal <<~CSV, run_etl(csv_options: {col_sep: ';'})
       name;age
       world;999
+    CSV
+  end
+  
+  def test_headers_provided
+    assert_equal <<~CSV, run_etl(headers: [:age])
+      age
+      999
     CSV
   end
 end


### PR DESCRIPTION
This PR adds some variation of a CSV destination. I've decided to only support `Hash` rows for now, since this is by far my most common pattern of use.

Later (after the public release of Kiba's `AlternateRunner`, see https://github.com/thbar/kiba/pull/41), this will likely be refactored to separate the output construction phase (e.g. deciding if we need headers or not) from the strict CSV output, but I preferred to have something out right now without that.

Also note that since Ruby 2.2 is [EOL in 3 months](https://www.ruby-lang.org/en/downloads/branches/), and `kiba-common` is fairly recent, I'm taking the liberty to require 2.3+ from now on, since this allows for nicer constructs in the code (please contact me if this is a huge problem for you to upgrade!).
