### PR TITLE
Implement Enumerable Exploder (requires Kiba v2 StreamingRunner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,37 @@ transform { |r| r.search('/orders') }
 transform Kiba::Common::Transforms::EnumerableExploder
 ```
 
+Similarly, if you have a CSV document as your input:
+
+| po_number  | buyers |
+| ------------- | ------------- |
+| 00001  | John:Mary:Sally  |
+
+and you want to reformat it to get this instead:
+
+| po_number | buyer |
+|-------------|---------|
+| 00001 | John |
+| 00001 | Mary |
+| 00001 | Sally |
+
+then you can explode them again with:
+
+```ruby
+source MyCSVSource, filename: "input.csv"
+
+transform do |row|
+  row.fetch(:buyers).split(':').map do |buyer|
+    { 
+      po_number: row.fetch(:po_number),
+      buyer: buyer
+    }
+  end
+end
+
+transform Kiba::Common::Transforms::EnumerableExploder
+```
+
 ### Kiba::Common::Destinations::CSV
 
 A way to dump `Hash` rows as CSV.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ You can pass a callable to make sure the evaluation will occur after your [pre-p
 source Kiba::Common::Sources::Enumerable, -> { Dir["input/*.json"] }
 ```
 
+### Kiba::Common::Transforms::EnumerableExploder
+
+A transform calling `each` on input rows (assuming they are e.g. arrays of sub-rows) and yielding one output row per enumerated element.
+
+Requirements: [Kiba v2](https://github.com/thbar/kiba/releases/tag/v2.0.0) with `StreamingRunner` enabled.
+
+Usage:
+
+```ruby
+require 'kiba-common/transforms/enumerable_exploder'
+
+transform Kiba::Common::Transforms::EnumerableExploder
+```
+
+For instance, this can help if you are reading XML/JSON documents from a source, and each input document contains multiple rows that you'd want to extract.
+
+```ruby
+source Kiba::Common::Sources::Enumerable, -> { Dir["input/*.xml"] }
+
+transform { |r| IO.binread(r) }
+transform { |r| Nokogiri::XML(r) }
+# this will return an array of XML elements
+transform { |r| r.search('/orders') }
+# this will explode the array (one order per output row)
+transform Kiba::Common::Transforms::EnumerableExploder
+```
+
 ### Kiba::Common::Destinations::CSV
 
 A way to dump `Hash` rows as CSV.

--- a/lib/kiba-common/transforms/enumerable_exploder.rb
+++ b/lib/kiba-common/transforms/enumerable_exploder.rb
@@ -1,0 +1,12 @@
+module Kiba
+  module Common
+    module Transforms
+      class EnumerableExploder
+        def process(row)
+          row.each { |r| yield r }
+          nil
+        end
+      end
+    end
+  end
+end

--- a/test/test_enumerable_exploder_transform.rb
+++ b/test/test_enumerable_exploder_transform.rb
@@ -1,0 +1,24 @@
+require_relative 'helper'
+require 'kiba'
+require_relative 'support/test_array_destination'
+require 'kiba-common/transforms/enumerable_exploder'
+require 'kiba/dsl_extensions/config'
+
+class TestEnumerableExploderTransform < Minitest::Test
+  def test_exploder
+    output = []
+    input = [[1,2],[3,4,5]]
+
+    job = Kiba.parse do
+      extend Kiba::DSLExtensions::Config
+      config :kiba, runner: Kiba::StreamingRunner
+
+      source Kiba::Common::Sources::Enumerable, input
+      transform Kiba::Common::Transforms::EnumerableExploder
+      destination TestArrayDestination, output
+    end
+    Kiba.run(job)
+    
+    assert_equal input.flatten, output
+  end
+end


### PR DESCRIPTION
This PR implements a new transform which is able to take a row responding to `each` and to generate N output rows for a given input row. This transform requires [Kiba v2 StreamingRunner](https://github.com/thbar/kiba/releases/tag/v2.0.0).

This is helpful for a lot of cases, including:

* Exploding a XML element with N children into N rows, like:

```xml
<item po_number="00001">
  <buyer>John</buyer>
  <buyer>Mary</buyer>
  <buyer>Sally>/buyer
</item>
```

into one row per buyer, like:

```ruby
{ po_number: '00001', buyer: 'John' }
{ po_number: '00001', buyer: 'Mary' }
{ po_number: '00001', buyer: 'Sally' }
```

* Exploding a CSV line containing flattened data like this:

| po_number  | buyers |
| ------------- | ------------- |
| 00001  | John:Mary:Sally  |

into this:

| po_number | buyer |
|-------------|---------|
| 00001 | John |
| 00001 | Mary |
| 00001 | Sally |