### PR TITLE
Implement a composable limiter

### DIFF
--- a/lib/kiba-common/sources/limiter.rb
+++ b/lib/kiba-common/sources/limiter.rb
@@ -1,0 +1,24 @@
+module Kiba
+  module Common
+    module Sources
+      class Limiter
+        attr_reader :limit, :source_class, :source_args
+        
+        def initialize(limit, source_class, *source_args)
+          @limit = limit
+          @source_class = source_class
+          @source_args = source_args
+        end
+        
+        def each
+          index = 0
+          source_class.new(*source_args).each do |row|
+            index += 1
+            break if limit && (index > limit)
+            yield row
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_limiter.rb
+++ b/test/test_limiter.rb
@@ -1,0 +1,14 @@
+require 'kiba-common/sources/limiter'
+
+class TestLimiter < Minitest::Test
+  def test_limiter
+    output = []
+    job = Kiba.parse do
+      source Kiba::Common::Sources::Limiter, 2,
+        Kiba::Common::Sources::Enumerable, (1..100)
+      destination TestArrayDestination, output
+    end
+    Kiba.run(job)
+    assert_equal [1, 2], output
+  end
+end


### PR DESCRIPTION
This implements a way to limit the rows of a given source, in a fashion that works for any source.

This needs more work to finalise the declaration protocol, but is working as is.