### PR TITLE
SourceTransformAdapter allows to instantiate sources based on input rows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 HEAD
 ----
 
+- New: Kiba::Common::Transforms::SourceTransformAdapter let you transform rows into parameters for source instantiation.
+
 0.6.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,37 @@ You can pass a callable to make sure the evaluation will occur after your [pre-p
 source Kiba::Common::Sources::Enumerable, -> { Dir["input/*.json"] }
 ```
 
+### Kiba::Common::Transforms::SourceTransformAdapter
+
+Let's say you have a source (e.g. `CSVSource`), which you would like to instantiate for each input row (e.g. a list of filenames). 
+
+Normally you'd have to bake file iteration right inside your source. 
+
+But since Kiba v2 introduction of `StreamingRunner`, it is possible for transforms to yield an arbitrary (potentially infinite) amount of rows.
+
+Leveraging that possibility, you can use a `SourceTransformAdapter` to dynamically instantiate the source for each of your input rows.
+
+This allows to mix-and-match components in a much more versatile & powerful way.
+
+Usage:
+
+```ruby
+source Kiba::Common::Sources::Enumerable, -> { Dir["input/*.csv"] }
+
+transform do |r|
+  # build up the args that you would normally pass to your source, e.g.
+  # source MyCSV, filename: 'file.csv'
+  # but instead, using the input as a parameter
+  [MyCSVSource, filename: r]
+end
+
+# this will instantiate one source per input row, yielding rows
+# that your source would normally yield
+transform Kiba::Common::Transforms::SourceTransformAdapter
+```
+
+This can be used for a wide array of scenarios, including extracting data for N third-party accounts of a same system, with an array of API keys etc.
+
 ### Kiba::Common::Transforms::EnumerableExploder
 
 A transform calling `each` on input rows (assuming they are e.g. arrays of sub-rows) and yielding one output row per enumerated element.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Leveraging that possibility, you can use a `SourceTransformAdapter` to dynamical
 
 This allows to mix-and-match components in a much more versatile & powerful way.
 
+Requirements: Kiba v2 with `StreamingRunner` enabled.
+
 Usage:
 
 ```ruby

--- a/kiba-common.gemspec
+++ b/kiba-common.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'awesome_print'
+  gem.add_development_dependency 'minitest-focus'
 end

--- a/lib/kiba-common/transforms/source_transform_adapter.rb
+++ b/lib/kiba-common/transforms/source_transform_adapter.rb
@@ -1,0 +1,8 @@
+class SourceTransformAdapter
+  def process(args)
+    args.shift.new(*args).each do |row|
+      yield(row)
+    end
+    nil
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'minitest/focus'
 
 require 'kiba-common/sources/enumerable'
 require_relative 'support/assert_called'

--- a/test/test_source_transform_adapter.rb
+++ b/test/test_source_transform_adapter.rb
@@ -1,0 +1,24 @@
+require_relative 'helper'
+require 'kiba-common/transforms/source_transform_adapter'
+
+class TestSourceTransformAdapter < Minitest::Test
+  include Kiba::Common::Sources
+  include Kiba::DSLExtensions
+
+  def test_instantiation
+    rows = []
+    job = Kiba.parse do
+      extend Config
+      config :kiba, runner: Kiba::StreamingRunner
+
+      source Enumerable, [
+        [ Enumerable, (1..10) ],
+        [ Enumerable, (11..20) ]
+      ]
+      transform SourceTransformAdapter
+      destination TestArrayDestination, rows
+    end
+    Kiba.run(job)
+    assert_equal (1..20).to_a, rows
+  end
+end


### PR DESCRIPTION
I've been using this for some weeks in various systems. It's a key component to make ETL pipelines more generic.

Code, tests & documentation attached.