### PR TITLE
Implement CSV source

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 HEAD
 ----
 
+- New: Kiba::Common::Sources::CSV provides a basic CSV source for simple needs.
+
 0.8.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ end
 transform Kiba::Common::Transforms::EnumerableExploder
 ```
 
+### Kiba::Common::Sources::CSV
+
+A CSV source for basic needs (in particular, it doesn't yield row metadata, which are useful in more advanced scenarios).
+
+Use the `csv_options` keyword to control the input format like when using [Ruby CSV class](http://ruby-doc.org/stdlib-2.4.0/libdoc/csv/rdoc/CSV.html#method-c-new).
+
+Usage:
+
+```ruby
+require 'kiba-common/sources/csv'
+
+# by defaults, csv_options are empty
+source Kiba::Common::Sources::CSV, filename: 'input.csv'
+
+# you can provide your own csv_options
+source Kiba::Common::Sources::CSV, filename: 'input.csv',
+  csv_options: { headers: true, header_converters: :symbol }
+```
+
 ### Kiba::Common::Destinations::CSV
 
 A way to dump `Hash` rows as CSV.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,43 @@ source Kiba::Common::Sources::CSV, filename: 'input.csv',
   csv_options: { headers: true, header_converters: :symbol }
 ```
 
+#### Handling multiple input CSV files
+
+You can process multiple files by chaining the various components available in Kiba Common (see `test/test_integration#test_multiple_csv_inputs` for an actual demo):
+
+```ruby
+# create one row per input filename
+source Kiba::Common::Sources::Enumerable, -> { Dir[File.join(dir, '*.csv')] }
+
+# out of that row, create configuration for a CSV source
+transform do |r|
+  [
+    Kiba::Common::Sources::CSV,
+    filename: r,
+    csv_options: { headers: true, header_converters: :symbol }
+  ]
+end
+
+# instantiate & yield CSV rows for each configuration
+transform Kiba::Common::Transforms::SourceTransformAdapter
+```
+
+Alternatively, you can wrap this source in your own source like this:
+
+```ruby
+class MultipleCSVSource
+  def initialize(file_pattern:, csv_options:)
+
+  def each
+    Dir[file_pattern].each do |filename|
+      Kiba::Common::Sources::CSV.new(filename, csv_options).each do |row|
+        yield row
+      end
+    end
+  end
+end
+```
+
 ### Kiba::Common::Destinations::CSV
 
 A way to dump `Hash` rows as CSV.

--- a/lib/kiba-common/sources/csv.rb
+++ b/lib/kiba-common/sources/csv.rb
@@ -1,0 +1,22 @@
+require 'csv'
+
+module Kiba
+  module Common
+    module Sources
+      class CSV
+        attr_reader :filename, :csv_options
+
+        def initialize(filename, csv_options: {})
+          @filename = filename
+          @csv_options = csv_options
+        end
+
+        def each
+          ::CSV.foreach(filename, csv_options) do |row|
+            yield row
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba-common/sources/csv.rb
+++ b/lib/kiba-common/sources/csv.rb
@@ -6,7 +6,7 @@ module Kiba
       class CSV
         attr_reader :filename, :csv_options
 
-        def initialize(filename, csv_options: {})
+        def initialize(filename:, csv_options: {})
           @filename = filename
           @csv_options = csv_options
         end

--- a/test/test_csv_source.rb
+++ b/test/test_csv_source.rb
@@ -1,0 +1,51 @@
+require_relative 'helper'
+require 'kiba'
+require 'kiba-common/sources/csv'
+require_relative 'support/test_array_destination'
+
+class TestCSVSource < MiniTest::Test
+  TEST_FILENAME = 'input.csv'
+
+  def setup
+    CSV.open(TEST_FILENAME, 'wb') do |csv|
+      csv << %w(first_name last_name)
+      csv << %w(John Barry)
+      csv << %w(Kate Bush)
+    end
+  end
+
+  def teardown
+    FileUtils.rm(TEST_FILENAME) if File.exist?(TEST_FILENAME)
+  end
+
+  def run_job(*args)
+    rows = []
+    job = Kiba.parse do
+      source Kiba::Common::Sources::CSV, *args
+      destination TestArrayDestination, rows
+    end
+    Kiba.run(job)
+    rows
+  end
+
+  def test_with_csv_options
+    rows = run_job TEST_FILENAME,
+      csv_options: { headers: true, header_converters: :symbol }
+
+    assert_equal [CSV::Row], rows.map(&:class).uniq
+    assert_equal([
+      {first_name: "John", last_name: "Barry" },
+      {first_name: "Kate", last_name: "Bush"}
+    ], rows.map(&:to_h))
+  end
+
+  def test_without_csv_options
+    rows = run_job(TEST_FILENAME)
+
+    assert_equal [
+      %w(first_name last_name),
+      %w(John Barry),
+      %w(Kate Bush)
+    ], rows
+  end
+end

--- a/test/test_csv_source.rb
+++ b/test/test_csv_source.rb
@@ -29,7 +29,7 @@ class TestCSVSource < MiniTest::Test
   end
 
   def test_with_csv_options
-    rows = run_job TEST_FILENAME,
+    rows = run_job filename: TEST_FILENAME,
       csv_options: { headers: true, header_converters: :symbol }
 
     assert_equal [CSV::Row], rows.map(&:class).uniq
@@ -40,7 +40,7 @@ class TestCSVSource < MiniTest::Test
   end
 
   def test_without_csv_options
-    rows = run_job(TEST_FILENAME)
+    rows = run_job(filename: TEST_FILENAME)
 
     assert_equal [
       %w(first_name last_name),

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -1,0 +1,52 @@
+require_relative 'helper'
+require 'kiba'
+require_relative 'support/test_array_destination'
+require 'kiba-common/transforms/source_transform_adapter'
+require 'kiba-common/sources/csv'
+require 'kiba-common/destinations/csv'
+
+# a testbed to verify & showcase how you can chain multiple components
+class TestIntegration < Minitest::Test
+  def write_csv(filename, data)
+    d = Kiba::Common::Destinations::CSV.new(filename: filename)
+    data.each { |r| d.write(r) }
+    d.close
+  end
+
+  def test_multiple_csv_inputs
+    Dir.mktmpdir do |dir|
+      write_csv File.join(dir, '001.csv'), [first_name: 'John']
+      write_csv File.join(dir, '002.csv'), [first_name: 'Kate']
+
+      rows = []
+      job = Kiba.parse do
+        # enable the new streaming-runner (for SourceTransformAdapter support)
+        extend Kiba::DSLExtensions::Config
+        config :kiba, runner: Kiba::StreamingRunner
+
+        # create one row per input file
+        source Kiba::Common::Sources::Enumerable, -> { Dir[File.join(dir, '*.csv')] }
+
+        # out of that row, create configuration for a CSV source
+        transform do |r|
+          [
+            Kiba::Common::Sources::CSV,
+            filename: r,
+            csv_options: { headers: true, header_converters: :symbol }
+          ]
+        end
+
+        # instantiate & yield CSV rows for each configuration
+        transform Kiba::Common::Transforms::SourceTransformAdapter
+
+        destination TestArrayDestination, rows
+      end
+      Kiba.run(job)
+
+      assert_equal([
+        { first_name: 'John' },
+        { first_name: 'Kate' }
+      ], rows.map(&:to_h))
+    end
+  end
+end


### PR DESCRIPTION
This will close #7.

Note that I've decided to remove more advanced bits from now (such as metadata handling, or post-file-process callbacks), which are useful in some scenarios, because I didn't have a super generic version of those yet, and future development of Kiba itself will impact how I will implement them.

Also, unlike suggested in #7, I'm not passing any defaults for `csv_options`, which means that the defaults will be those applied by Ruby's CSV library itself. It's not a huge pain since on most projects, these options will be DRY'ed somewhere anyway.