### PR TITLE
Fix brittle test

### DIFF
--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -25,7 +25,7 @@ class TestIntegration < Minitest::Test
         config :kiba, runner: Kiba::StreamingRunner
 
         # create one row per input file
-        source Kiba::Common::Sources::Enumerable, -> { Dir[File.join(dir, '*.csv')] }
+        source Kiba::Common::Sources::Enumerable, -> { Dir[File.join(dir, '*.csv')].sort }
 
         # out of that row, create configuration for a CSV source
         transform do |r|


### PR DESCRIPTION
The file ordering is making the test fail on TravisCI, because the behaviour of the OS is different from what I have locally. This ensures the order is deterministic.