### PR TITLE
Implement "lambda" destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,30 @@ destination Kiba::Common::Destinations::CSV,
   headers: [:field, :other_field]
 ```
 
+### Kiba::Common::Destinations::Lambda
+
+At times, it can be convenient to use a block form for a destination (pretty much like Kiba's built-in "block transform"), especially for one-off scripts.
+
+The Lambda destination is there for that purpose.
+
+Example use:
+
+```ruby
+require 'kiba-common/destinations/lambda'
+
+destination Kiba::Common::Destinations::Lambda,
+  # called at destination instantiation time (once)
+  on_init: -> { ... },
+  # called for each row
+  on_write: -> (row) { ... },
+  # called after all the rows have been written
+  on_close: -> { ... }
+```
+
+Each "callback" (e.g. `on_init`) is optional.
+
+The callback code can refer to scope variables or instance variables you may have declared above.
+
 ### Kiba::Common::DSLExtensions::Logger
 
 A simple logging facility.

--- a/lib/kiba-common/destinations/lambda.rb
+++ b/lib/kiba-common/destinations/lambda.rb
@@ -1,0 +1,23 @@
+module Kiba
+  module Common
+    module Destinations
+      class Lambda
+        attr_reader :on_write, :on_close
+        
+        def initialize(on_init: nil, on_write: nil, on_close: nil)
+          @on_write = on_write
+          @on_close = on_close
+          on_init&.call
+        end
+
+        def write(row)
+          on_write&.call(row)
+        end
+
+        def close
+          on_close&.call
+        end
+      end
+    end
+  end
+end

--- a/test/test_lambda_destination.rb
+++ b/test/test_lambda_destination.rb
@@ -1,0 +1,22 @@
+require_relative 'helper'
+require 'kiba'
+require 'kiba-common/destinations/lambda'
+
+class TestLambdaDestination < MiniTest::Test
+  def test_lambda
+    accumulator = []
+    on_init_called = false
+    on_close_called = false
+    job = Kiba.parse do
+      source Kiba::Common::Sources::Enumerable, ['one', 'two']
+      destination Kiba::Common::Destinations::Lambda,
+        on_init: -> { on_init_called = true },
+        on_write: -> (r) { accumulator << r },
+        on_close: -> { on_close_called = true }
+    end
+    Kiba.run(job)
+    assert_equal ['one', 'two'], accumulator
+    assert_equal true, on_init_called
+    assert_equal true, on_close_called
+  end
+end


### PR DESCRIPTION
This implements a block-form destination, convenient for one-off scripts.