### PR TITLE
Make sure kiba-common can be used with Kiba v3

### DIFF
--- a/kiba-common.gemspec
+++ b/kiba-common.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Kiba::Common::VERSION
 
-  gem.add_dependency 'kiba', '>= 1.0.0', '< 3'
+  gem.add_dependency 'kiba', '>= 1.0.0', '< 4'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'awesome_print'


### PR DESCRIPTION
This PR relaxes the version dependency on Kiba, to allow use with the upcoming v3.