### PR TITLE
Implement a generic destination row pre-processor

### DIFF
--- a/lib/kiba-common/destinations/destination_pre_processor.rb
+++ b/lib/kiba-common/destinations/destination_pre_processor.rb
@@ -2,16 +2,16 @@ module Kiba
   module Common
     module Destinations
       class DestinationPreProcessor
-        attr_reader :pre_processor, :destination
+        attr_reader :row_pre_processor, :destination
 
         def initialize(config)
-          @pre_processor = config.fetch(:pre_processor)
+          @row_pre_processor = config.fetch(:row_pre_processor)
           klass, *args = config.fetch(:destination)
           @destination = klass.new(*args)
         end
         
         def write(row)
-          processed_row = pre_processor.call(row)
+          processed_row = row_pre_processor.call(row)
           destination.write(processed_row) unless processed_row.nil?
         end
         

--- a/lib/kiba-common/destinations/destination_pre_processor.rb
+++ b/lib/kiba-common/destinations/destination_pre_processor.rb
@@ -1,0 +1,25 @@
+module Kiba
+  module Common
+    module Destinations
+      class DestinationPreProcessor
+        attr_reader :pre_processor, :destination
+
+        def initialize(config)
+          @pre_processor = config.fetch(:pre_processor)
+          klass, *args = config.fetch(:destination)
+          @destination = klass.new(*args)
+        end
+        
+        def write(row)
+          processed_row = pre_processor.call(row)
+          destination.write(processed_row) unless processed_row.nil?
+        end
+        
+        def close
+          destination&.close
+          @destination = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba-common/destinations/destination_pre_processor.rb
+++ b/lib/kiba-common/destinations/destination_pre_processor.rb
@@ -16,7 +16,7 @@ module Kiba
         end
         
         def close
-          destination&.close
+          destination.close if destination&.respond_to?(:close)
           @destination = nil
         end
       end

--- a/test/test_row_pre_processor_destination.rb
+++ b/test/test_row_pre_processor_destination.rb
@@ -26,4 +26,19 @@ class TestRowPreProcessorDestination < MiniTest::Test
     assert_equal [102, 104, 106, 108, 110], output
     assert_equal true, close_called
   end
+
+  def test_do_not_raise_if_destination_lacks_a_close_method
+    output = []
+    instance = Lambda.new(on_write: -> (r) { output << r })
+    instance.instance_eval('undef :close')
+    Lambda.stub(:new, instance) do
+      Kiba.run(Kiba.parse do
+        source Enumerable, (1..10)
+        destination DestinationPreProcessor,
+          row_pre_processor: -> (r) { r },
+          destination: [ Lambda ]
+      end)
+      assert_equal (1..10).to_a, output
+    end
+  end
 end

--- a/test/test_row_pre_processor_destination.rb
+++ b/test/test_row_pre_processor_destination.rb
@@ -1,0 +1,29 @@
+require_relative 'helper'
+require 'kiba'
+require 'kiba-common/destinations/destination_pre_processor'
+require 'kiba-common/destinations/lambda'
+
+class TestRowPreProcessorDestination < MiniTest::Test
+  include Kiba::Common::Destinations
+  include Kiba::Common::Sources
+  
+  focus
+  def test_filter_and_modify
+    output = []
+    close_called = false
+    job = Kiba.parse do
+      source Enumerable, (1..10)
+      destination DestinationPreProcessor,
+        pre_processor: -> (r) { r % 2 == 0 ? 100 + r : nil },
+        destination: [
+          Lambda,
+          on_write: -> (r) { output << r },
+          on_close: -> { close_called = true }
+        ]
+    end
+    Kiba.run(job)
+    
+    assert_equal [102, 104, 106, 108, 110], output
+    assert_equal true, close_called
+  end
+end

--- a/test/test_row_pre_processor_destination.rb
+++ b/test/test_row_pre_processor_destination.rb
@@ -7,7 +7,6 @@ class TestRowPreProcessorDestination < MiniTest::Test
   include Kiba::Common::Destinations
   include Kiba::Common::Sources
   
-  focus
   def test_filter_and_modify
     output = []
     close_called = false

--- a/test/test_row_pre_processor_destination.rb
+++ b/test/test_row_pre_processor_destination.rb
@@ -14,7 +14,7 @@ class TestRowPreProcessorDestination < MiniTest::Test
     job = Kiba.parse do
       source Enumerable, (1..10)
       destination DestinationPreProcessor,
-        pre_processor: -> (r) { r % 2 == 0 ? 100 + r : nil },
+        row_pre_processor: -> (r) { r % 2 == 0 ? 100 + r : nil },
         destination: [
           Lambda,
           on_write: -> (r) { output << r },


### PR DESCRIPTION
This PR implements a way to filter and "modify" (but you'll want to avoid mutating the input instance if you do so) rows before they are actually sent to the destination.

This replaces #29 (an implementation specific to `CSVDestination`) by something that can be used for any destination.

A few notes are warranted:
- Unlike [Kiba Pro's SQL Bulk Insert/Upsert destination](https://github.com/thbar/kiba/wiki/SQL-Bulk-Insert-Upsert-Destination), the pre-processor can only generate a single output row, or none, but not N. It would be easy to add support for N rows, but the exact implementation will differ massively depending on which directions I take for Kiba & Kiba Pro in the next iterations, so I prefer to keep things simple.
- This PR does not tackle support for Ruby 2.7/2.8. This will be implemented via #27 if the current PR gets merged ultimately.
- I'm facing an error on TruffleRuby, which I'll investigate before this gets merged

### Remaining tasks

- [ ] Add proper documentation to `kiba-common` and Kiba's wiki based on #30 

### Basic example of use

```ruby
require 'kiba-common/destinations/destination_pre_processor'

 # Here we'll route based on some field value
 destination Kiba::Common::Destinations::DestinationPreProcessor,
   row_pre_processor: -> (r) { r.fetch(:type) == 1 ? r : nil },
   destination: [ MyDestinationClass, my_destination_config... ]

 # Here we decide that everything that wasn't handled before, must be handled now
 destination Kiba::Common::Destinations::DestinationPreProcessor,
   row_pre_processor: -> (r) { r.fetch(:type) != 1 ? r : nil },
   destination: [ MyDestinationClass, my_other_destination_config... ]
```

For creating changed rows:

```ruby
destination Kiba::Common::Destinations::DestinationPreProcessor,
  row_pre_processor: -> (row) {
    # Create a new row, converting the keys to symbols
    row.each_with_object({}) do |r, (k, v)|
      r[k.to_sym] = v
    end
  },
  destination: [ MyDestinationClass, my_destination_config... ]
```